### PR TITLE
Add hostname and MAC address to adguard-vpn-cli

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
         image: supersunho/adguardvpn-cli:latest
         restart: unless-stopped
         container_name: adguard-vpn-cli
+        hostname: adguard-vpn-cli
+        mac_address: "02:42:ac:11:00:02" # Choose a fixed, unique MAC address
         env_file: .env
         volumes:
             - ./data:/root/.local/share/adguardvpn-cli


### PR DESCRIPTION
Set a fixed MAC address and hostname for the adguard-vpn-cli service.

With these settings in place, the machine ID remains stable, allowing the container to survive Docker restarts and even full container recreation without requiring re-authentication.